### PR TITLE
Allow BdSpiderMastermind to be crushed in Doom 2 MAP06

### DIFF
--- a/pk3/decorate/monsters/Mastermind.txt
+++ b/pk3/decorate/monsters/Mastermind.txt
@@ -22,7 +22,6 @@ ACTOR BdSpiderMastermind : BdLiteMonster Replaces SpiderMastermind
     +NORADIUSDMG
     +NOBLOOD
     +MISSILEMORE
-    -SOLID
     +MISSILEEVENMORE
     +SHOOTABLE
     SeeSound "spider/sight"


### PR DESCRIPTION
Monsters marked as not solid using the -SOLID flag do not appear to receive crush damage in latest tested version of GZDoom (4.5.0).